### PR TITLE
E p 3 GitHub item 3 probe kill wrong sr

### DIFF
--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -389,7 +389,8 @@ cmCombinedState cm_get_combined_state(cmMachine_t *_cm)
                 case CYCLE_NONE:      { break; } // CYCLE_NONE cannot ever get here
                 case CYCLE_MACHINING: { return (_cm->hold_state == FEEDHOLD_OFF ? COMBINED_RUN : COMBINED_HOLD); }
                 case CYCLE_HOMING:    { return (COMBINED_HOMING); }
-                case CYCLE_PROBE:     { return (COMBINED_PROBE); }
+                //case CYCLE_PROBE:     { return (COMBINED_PROBE); }
+                case CYCLE_PROBE:     { return (_cm->hold_state == FEEDHOLD_OFF ? COMBINED_PROBE : COMBINED_HOLD); }
                 case CYCLE_JOG:       { return (COMBINED_JOG); }
             }
         }

--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -389,7 +389,6 @@ cmCombinedState cm_get_combined_state(cmMachine_t *_cm)
                 case CYCLE_NONE:      { break; } // CYCLE_NONE cannot ever get here
                 case CYCLE_MACHINING: { return (_cm->hold_state == FEEDHOLD_OFF ? COMBINED_RUN : COMBINED_HOLD); }
                 case CYCLE_HOMING:    { return (COMBINED_HOMING); }
-                //case CYCLE_PROBE:     { return (COMBINED_PROBE); }
                 case CYCLE_PROBE:     { return (_cm->hold_state == FEEDHOLD_OFF ? COMBINED_PROBE : COMBINED_HOLD); }
                 case CYCLE_JOG:       { return (COMBINED_JOG); }
             }

--- a/g2core/g2core.cppproj
+++ b/g2core/g2core.cppproj
@@ -25,8 +25,8 @@
     <avrtool>com.atmel.avrdbg.tool.samice</avrtool>
     <com_atmel_avrdbg_tool_samice>
       <ToolType>com.atmel.avrdbg.tool.samice</ToolType>
-      <ToolName>SAM-ICE</ToolName>
-      <ToolNumber>28012829</ToolNumber>
+      <ToolName>J-Link</ToolName>
+      <ToolNumber>51013548</ToolNumber>
       <Channel>
         <host>127.0.0.1</host>
         <port>1063</port>
@@ -54,15 +54,15 @@
     </com_atmel_avrdbg_tool_samice>
     <AsfFrameworkConfig>
       <framework-data>
-        <options />
-        <configurations />
-        <files />
-        <documentation help="" />
-        <offline-documentation help="" />
-        <dependencies>
-          <content-extension eid="atmel.asf" uuidref="Atmel.ASF" version="3.34.1" />
-        </dependencies>
-      </framework-data>
+  <options />
+  <configurations />
+  <files />
+  <documentation help="" />
+  <offline-documentation help="" />
+  <dependencies>
+    <content-extension eid="atmel.asf" uuidref="Atmel.ASF" version="3.42.0" />
+  </dependencies>
+</framework-data>
     </AsfFrameworkConfig>
     <CacheFlash>true</CacheFlash>
     <ProgFlashFromRam>true</ProgFlashFromRam>
@@ -104,7 +104,7 @@
       <HWProgramCounterSampling>True</HWProgramCounterSampling>
     </PercepioTrace>
     <preserveEEPROM>true</preserveEEPROM>
-    <avrtoolserialnumber>28012829</avrtoolserialnumber>
+    <avrtoolserialnumber>51013548</avrtoolserialnumber>
     <avrdeviceexpectedsignature>0x285E0A60</avrdeviceexpectedsignature>
     <avrtoolinterfaceclock>4000000</avrtoolinterfaceclock>
     <custom>


### PR DESCRIPTION
Submitting fix for Github issue #3 or 20A. While probing "g38.3" if a feedhold is issued "stat:6" will now be properly reported.
This was tested again after issue 20B or issue #4 was merged into e-p-3 and was still working.

**2 NOTES:**

1. Reported hold states now vary a bit. Before "hold:4" followed by "hold:0" were VERY common. Now they sometimes happen. Other times other hold states or no hold state is reported (which should be indicating it finished rapidly before a SR was generated). Primarily 3 hold patterns emerged in testing.

- hold4: followed by hold:0
- hold7: followed by hold:0
- No hold state reported

2. This fixes the G2 side of issuing a feedhold in a probe to fix the FabMo hang and this works in Serial just fine. In FabMo though hitting "resume" does not resume and simply kills it. This is probably due to the "kill command" work around FabMo had been using on its side as a work around?