### PR TITLE
Z-lift on feedhold should only move up, not down to safe height.

### DIFF
--- a/g2core/cycle_feedhold.cpp
+++ b/g2core/cycle_feedhold.cpp
@@ -807,7 +807,7 @@ stat_t _feedhold_with_actions()          // Execute Case (5)
             float target[] = { 0,0,0,0,0,0 };
             bool skip_move = false;
             if (cm->feedhold_z_lift < 0) {  // if the value is negative, we want to go to Z-max position with G53
-                if (cm->homed[AXIS_Z]) {    // ONLY IF HOMED
+                if (cmHomingState::HOMING_HOMED == cm->homed[AXIS_Z]) {    // ONLY IF HOMED
                     cm_set_absolute_override(MODEL, ABSOLUTE_OVERRIDE_ON_DISPLAY_WITH_OFFSETS);  // Position stored in abs coords
                     cm_set_distance_mode(ABSOLUTE_DISTANCE_MODE);           // Must run in absolute distance mode
                     target[AXIS_Z] = cm->a[AXIS_Z].travel_max;
@@ -820,7 +820,7 @@ stat_t _feedhold_with_actions()          // Execute Case (5)
                 ////## Need Z to pull to fixed location; 
                 ////##  and, BETTER pull to fixed location if not above
                 cm_set_distance_mode(ABSOLUTE_DISTANCE_MODE);
-                if (cm->gmx.position[AXIS_Z] < cm->feedhold_z_lift) {
+                if (cm->gmx.position[AXIS_Z] - cm_get_combined_offset(AXIS_Z) < cm->feedhold_z_lift) {
                     target[AXIS_Z] = cm->feedhold_z_lift;
                 } else {
                     skip_move = true;


### PR DESCRIPTION
Added in the code to use the combined offsets to determine current
location.

This is a resubmission of a previous pull request that accidentally got merged to main and then reverted. Now merging to e-p-3 like it was supposted to be.  Code already reviewed by Ted on the other PR.