### PR TITLE
E p 3 item 24 m5 spindle on/off

### DIFF
--- a/g2core/cycle_feedhold.cpp
+++ b/g2core/cycle_feedhold.cpp
@@ -664,15 +664,7 @@ void _enter_p2()
     cm2.queue_flush_state = QUEUE_FLUSH_OFF;
     cm2.gm.feed_rate = 0;
     cm2.arc.run_state = BLOCK_INACTIVE;     // Stop a running p1 arc from continuing to execute in p2
-
-    // mp1_queue->bf->gm->spindle_speed
-    mpBuf_t *cat = mp1_queue;
-    while (cat->gm.spindle_speed != 0.0) {
-        cat = cat->nx;
-        if (cat->gm.spindle_direction != SPINDLE_OFF) {
-            cm2.gm.spindle_direction = cat->gm.spindle_direction;
-        }
-    }
+    cm2.gm.spindle_direction = mp_get_r()->gm.spindle_direction; // Preserves spindle direction in short files or when near EOF
 
     // Set mp planner to p2 and reset it
     cm2.mp = &mp2;

--- a/g2core/cycle_feedhold.cpp
+++ b/g2core/cycle_feedhold.cpp
@@ -665,6 +665,15 @@ void _enter_p2()
     cm2.gm.feed_rate = 0;
     cm2.arc.run_state = BLOCK_INACTIVE;     // Stop a running p1 arc from continuing to execute in p2
 
+    // mp1_queue->bf->gm->spindle_speed
+    mpBuf_t *cat = mp1_queue;
+    while (cat->gm.spindle_speed != 0.0) {
+        cat = cat->nx;
+        if (cat->gm.spindle_direction != SPINDLE_OFF) {
+            cm2.gm.spindle_direction = cat->gm.spindle_direction;
+        }
+    }
+
     // Set mp planner to p2 and reset it
     cm2.mp = &mp2;
     planner_reset((mpPlanner_t *)cm2.mp);   // mp is a void pointer

--- a/g2core/cycle_feedhold.cpp
+++ b/g2core/cycle_feedhold.cpp
@@ -659,12 +659,15 @@ void _enter_p2()
     // Set parameters in cm, gm and gmx so you can actually use it
     memcpy(&cm2, &cm1, sizeof(cmMachine_t));
     cm2.hold_state = FEEDHOLD_OFF;
+    mpBuf_t *bf = mp_get_run_buffer();      // Get the current valid run buffer
+    if (bf) { 
+        cm2.gm = bf->gm;                    // Set gm to a copy of the current run buffer's gm
+    }
     cm2.gm.motion_mode = MOTION_MODE_CANCEL_MOTION_MODE;
     cm2.gm.absolute_override = ABSOLUTE_OVERRIDE_OFF;
     cm2.queue_flush_state = QUEUE_FLUSH_OFF;
     cm2.gm.feed_rate = 0;
     cm2.arc.run_state = BLOCK_INACTIVE;     // Stop a running p1 arc from continuing to execute in p2
-    cm2.gm.spindle_direction = mp_get_r()->gm.spindle_direction; // Preserves spindle direction in short files or when near EOF
 
     // Set mp planner to p2 and reset it
     cm2.mp = &mp2;


### PR DESCRIPTION
This fixes the issue with the spindle not retaining it's settings after a feedhold in short files or when feedheld near the end of a file. It also saves the entire current running buffers "gm" for restoration after exiting the feedhold. So a few other unnoticed broken settings will likely be restored now too.

"out1" should now update correctly to 0 when a feedhold occurs and back to 1 after resuming.