### PR TITLE
E p 3 item 19 m30 doesn't trigger stat4

### DIFF
--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -1705,6 +1705,7 @@ stat_t cm_m48_enable(uint8_t enable)        // M48, M49
  * cm_program_stop()            - M0 - performs NIST STOP functions
  * cm_optional_program_stop()   - M1 - conditionally performs NIST STOP functions
  * cm_program_end()             - M2, M30 - performs NIST END functions (with some differences)
+ * cm_is_in_program_end_state() - Returns 0 if any of the conditions of an M2/M30 are not set and returns 1 if they ALL are
  */
 /*
  * Program and cycle state functions
@@ -1833,14 +1834,11 @@ void cm_program_end()
 }
 
 stat_t cm_is_in_program_end_state() {
-    if (!(cm->gm.spindle_direction == SPINDLE_OFF && cm->gm.spindle_speed == 0)) {return 0; }
+    // Checking for all the conditions that an M2/M30 sets
+    if (!(cm->gm.spindle_direction == SPINDLE_OFF && cm->gm.spindle_speed == 0)) { return 0; }
     if (!(coolant.mist.state == COOLANT_OFF && coolant.flood.state == COOLANT_OFF)) { return 0; }
-    //temperature_reset();
-    //if (pid1._set_point == 0.0) { return 0; }
     if (!(cm->gmx.m48_enable == true && cm->gmx.mfo_enable == true && cm->gmx.mfo_factor == 1.0 && cm->gmx.mto_enable == true && cm->gmx.mto_factor == 1.0)) { return 0; }
-    //
-    
-    //if (!(cm->gmx.g92_offset_enable == true)) { return 0; }
+    if (!(cm->gmx.g92_offset_enable == false)) { return 0; }
     if (!(cm->gm.coord_system == cm->default_coord_system)) { return 0; }
     if (!(cm->gm.select_plane == cm->default_select_plane)) { return 0; }
     if (!(cm->gm.units_mode == cm->default_distance_mode)) { return 0; }
@@ -1848,7 +1846,7 @@ stat_t cm_is_in_program_end_state() {
     if (!(cm->gm.feed_rate_mode == UNITS_PER_MINUTE_MODE)) { return 0; }
     if (!(cm->gm.motion_mode == MOTION_MODE_CANCEL_MOTION_MODE)) { return 0; }
     
-    return 1;
+    return 1; // All conditions met
 }
 
 /****************************************************************************************

--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -1747,11 +1747,14 @@ stat_t cm_m48_enable(uint8_t enable)        // M48, M49
 
 static void _exec_program_finalize(float* value, bool* flag) {
     // perform the following resets if it's a program END
-    if (cm->machine_state == MACHINE_PROGRAM_END) {
+    //if (cm->machine_state == MACHINE_PROGRAM_END) {
+    if (flag) {   
         spindle_stop();             // immediate M5
         coolant_control_immediate(COOLANT_OFF,COOLANT_BOTH);// immediate M9
         temperature_reset();                                // turn off all heaters and fans
         cm_reset_overrides();                               // enable G48, reset feed rate, traverse and spindle overrides
+        cm->machine_state = MACHINE_PROGRAM_END;
+        cm->cycle_type = CYCLE_NONE;
     }
 
     sr_request_status_report(SR_REQUEST_IMMEDIATE);         // request a final and full status report (not filtered)
@@ -1785,10 +1788,11 @@ static void _exec_program_stop_end(cmMachineState machine_state)
 
         // the rest will be queued and executed in _exec_program_finalize()
     }
-
+    bool x = true;
     cm_set_motion_state(MOTION_STOP);                       // also changes active model back to MODEL
 
-    mp_queue_command(_exec_program_finalize, nullptr, nullptr);
+    //mp_queue_command(_exec_program_finalize, nullptr, nullptr);
+    mp_queue_command(_exec_program_finalize, nullptr, &x);
 }
 
 // Will start a cycle regardless of whether the planner has moves or not

--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -1835,21 +1835,18 @@ void cm_program_end()
 
 stat_t cm_is_in_program_end_state() {
     // Checking for all the conditions that an M2/M30 sets
-    if (!(cm->gm.spindle_direction == SPINDLE_OFF 
-       && (cm->gm.spindle_speed <= BASE_STATE_SPINDLE_STOPPED 
-       &&  cm->gm.spindle_speed >= BASE_STATE_SPINDLE_STOPPED)))                                       { return 0; }
-    if (!(coolant.mist.state == COOLANT_OFF && coolant.flood.state == COOLANT_OFF))                    { return 0; }
+    if (!(cm->gm.spindle_direction == SPINDLE_OFF && fp_EQ(cm->gm.spindle_speed, BASE_STATE_SPINDLE_STOPPED))) { return 0; }
+    if (!(coolant.mist.state == COOLANT_OFF && coolant.flood.state == COOLANT_OFF))                            { return 0; }
     if (!(cm->gmx.m48_enable == true && cm->gmx.mfo_enable == true 
-       && (cm->gmx.mfo_factor <= BASE_STATE_MFO_FACTOR && cm->gmx.mfo_factor >= BASE_STATE_MFO_FACTOR) 
-       && (cm->gmx.mto_factor <= BASE_STATE_MTO_FACTOR && cm->gmx.mto_factor >= BASE_STATE_MTO_FACTOR)
-       && cm->gmx.mto_enable == true ))                                                                { return 0; }
-    if (!(cm->gmx.g92_offset_enable == false))                                                         { return 0; }
-    if (!(cm->gm.coord_system == cm->default_coord_system))                                            { return 0; }
-    if (!(cm->gm.select_plane == cm->default_select_plane))                                            { return 0; }
-    if (!(cm->gm.distance_mode == cm->default_distance_mode))                                          { return 0; }
-    if (!(cm->gm.arc_distance_mode == INCREMENTAL_DISTANCE_MODE))                                      { return 0; }
-    if (!(cm->gm.feed_rate_mode == UNITS_PER_MINUTE_MODE))                                             { return 0; }
-    if (!(cm->gm.motion_mode == MOTION_MODE_CANCEL_MOTION_MODE))                                       { return 0; }
+       && fp_EQ(cm->gmx.mfo_factor, BASE_STATE_MFO_FACTOR) && fp_EQ(cm->gmx.mto_factor, BASE_STATE_MTO_FACTOR)
+       && cm->gmx.mto_enable == true ))                                                                        { return 0; }
+    if (!(cm->gmx.g92_offset_enable == false))                                                                 { return 0; }
+    if (!(cm->gm.coord_system == cm->default_coord_system))                                                    { return 0; }
+    if (!(cm->gm.select_plane == cm->default_select_plane))                                                    { return 0; }
+    if (!(cm->gm.distance_mode == cm->default_distance_mode))                                                  { return 0; }
+    if (!(cm->gm.arc_distance_mode == INCREMENTAL_DISTANCE_MODE))                                              { return 0; }
+    if (!(cm->gm.feed_rate_mode == UNITS_PER_MINUTE_MODE))                                                     { return 0; }
+    if (!(cm->gm.motion_mode == MOTION_MODE_CANCEL_MOTION_MODE))                                               { return 0; }
     
     return 1; // All conditions met
 }

--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -1558,9 +1558,9 @@ void cm_reset_overrides()
 {
     cm->gmx.m48_enable = true;
     cm->gmx.mfo_enable = true;  // feed rate overrides
-    cm->gmx.mfo_factor = 1.0;
+    cm->gmx.mfo_factor = BASE_STATE_MFO_FACTOR;
     cm->gmx.mto_enable = true;  // traverse overrides
-    cm->gmx.mto_factor = 1.0;
+    cm->gmx.mto_factor = BASE_STATE_MTO_FACTOR;
 }
 
 /****************************************************************************************
@@ -1835,16 +1835,21 @@ void cm_program_end()
 
 stat_t cm_is_in_program_end_state() {
     // Checking for all the conditions that an M2/M30 sets
-    if (!(cm->gm.spindle_direction == SPINDLE_OFF && cm->gm.spindle_speed == 0)) { return 0; }
-    if (!(coolant.mist.state == COOLANT_OFF && coolant.flood.state == COOLANT_OFF)) { return 0; }
-    if (!(cm->gmx.m48_enable == true && cm->gmx.mfo_enable == true && cm->gmx.mfo_factor == 1.0 && cm->gmx.mto_enable == true && cm->gmx.mto_factor == 1.0)) { return 0; }
-    if (!(cm->gmx.g92_offset_enable == false)) { return 0; }
-    if (!(cm->gm.coord_system == cm->default_coord_system)) { return 0; }
-    if (!(cm->gm.select_plane == cm->default_select_plane)) { return 0; }
-    if (!(cm->gm.units_mode == cm->default_distance_mode)) { return 0; }
-    if (!(cm->gm.arc_distance_mode == INCREMENTAL_DISTANCE_MODE)) { return 0; }
-    if (!(cm->gm.feed_rate_mode == UNITS_PER_MINUTE_MODE)) { return 0; }
-    if (!(cm->gm.motion_mode == MOTION_MODE_CANCEL_MOTION_MODE)) { return 0; }
+    if (!(cm->gm.spindle_direction == SPINDLE_OFF 
+       && (cm->gm.spindle_speed <= BASE_STATE_SPINDLE_STOPPED 
+       &&  cm->gm.spindle_speed >= BASE_STATE_SPINDLE_STOPPED)))                                       { return 0; }
+    if (!(coolant.mist.state == COOLANT_OFF && coolant.flood.state == COOLANT_OFF))                    { return 0; }
+    if (!(cm->gmx.m48_enable == true && cm->gmx.mfo_enable == true 
+       && (cm->gmx.mfo_factor <= BASE_STATE_MFO_FACTOR && cm->gmx.mfo_factor >= BASE_STATE_MFO_FACTOR) 
+       && (cm->gmx.mto_factor <= BASE_STATE_MTO_FACTOR && cm->gmx.mto_factor >= BASE_STATE_MTO_FACTOR)
+       && cm->gmx.mto_enable == true ))                                                                { return 0; }
+    if (!(cm->gmx.g92_offset_enable == false))                                                         { return 0; }
+    if (!(cm->gm.coord_system == cm->default_coord_system))                                            { return 0; }
+    if (!(cm->gm.select_plane == cm->default_select_plane))                                            { return 0; }
+    if (!(cm->gm.distance_mode == cm->default_distance_mode))                                          { return 0; }
+    if (!(cm->gm.arc_distance_mode == INCREMENTAL_DISTANCE_MODE))                                      { return 0; }
+    if (!(cm->gm.feed_rate_mode == UNITS_PER_MINUTE_MODE))                                             { return 0; }
+    if (!(cm->gm.motion_mode == MOTION_MODE_CANCEL_MOTION_MODE))                                       { return 0; }
     
     return 1; // All conditions met
 }

--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -1832,6 +1832,25 @@ void cm_program_end()
     _exec_program_stop_end(MACHINE_PROGRAM_END);
 }
 
+stat_t cm_is_in_program_end_state() {
+    if (!(cm->gm.spindle_direction == SPINDLE_OFF && cm->gm.spindle_speed == 0)) {return 0; }
+    if (!(coolant.mist.state == COOLANT_OFF && coolant.flood.state == COOLANT_OFF)) { return 0; }
+    //temperature_reset();
+    //if (pid1._set_point == 0.0) { return 0; }
+    if (!(cm->gmx.m48_enable == true && cm->gmx.mfo_enable == true && cm->gmx.mfo_factor == 1.0 && cm->gmx.mto_enable == true && cm->gmx.mto_factor == 1.0)) { return 0; }
+    //
+    
+    //if (!(cm->gmx.g92_offset_enable == true)) { return 0; }
+    if (!(cm->gm.coord_system == cm->default_coord_system)) { return 0; }
+    if (!(cm->gm.select_plane == cm->default_select_plane)) { return 0; }
+    if (!(cm->gm.units_mode == cm->default_distance_mode)) { return 0; }
+    if (!(cm->gm.arc_distance_mode == INCREMENTAL_DISTANCE_MODE)) { return 0; }
+    if (!(cm->gm.feed_rate_mode == UNITS_PER_MINUTE_MODE)) { return 0; }
+    if (!(cm->gm.motion_mode == MOTION_MODE_CANCEL_MOTION_MODE)) { return 0; }
+    
+    return 1;
+}
+
 /****************************************************************************************
  **** Additional Functions **************************************************************
  ****************************************************************************************/

--- a/g2core/canonical_machine.h
+++ b/g2core/canonical_machine.h
@@ -470,7 +470,7 @@ stat_t cm_m48_enable(uint8_t enable);                           // M48, M49
 
 // Program Functions (4.3.10)
 void cm_cycle_start(void);                                      // (no Gcode)
-void cm_cycle_end(void);                                        // (no Gcode)
+void cm_cycle_end(bool from_command = false);                   // (no Gcode)
 void cm_canned_cycle_end(void);                                 // end of canned cycle
 void cm_program_stop(void);                                     // M0
 void cm_optional_program_stop(void);                            // M1

--- a/g2core/canonical_machine.h
+++ b/g2core/canonical_machine.h
@@ -55,9 +55,9 @@
 #define JERK_INPUT_MAX      (1000000)       // maximum allowable jerk setting in millions mm/min^3
 #define PROBES_STORED       3               // we store three probes for coordinate rotation computation
 #define MAX_LINENUM         2000000000      // set 2 billion as max line number
-#define BASE_STATE_SPINDLE_STOPPED 0
-#define BASE_STATE_MFO_FACTOR 1.0
-#define BASE_STATE_MTO_FACTOR 1.0
+#define BASE_STATE_SPINDLE_STOPPED 0.0f
+#define BASE_STATE_MFO_FACTOR 1.0f
+#define BASE_STATE_MTO_FACTOR 1.0f
 
 /*****************************************************************************
  * MACHINE STATE MODEL

--- a/g2core/canonical_machine.h
+++ b/g2core/canonical_machine.h
@@ -475,6 +475,7 @@ void cm_canned_cycle_end(void);                                 // end of canned
 void cm_program_stop(void);                                     // M0
 void cm_optional_program_stop(void);                            // M1
 void cm_program_end(void);                                      // M2
+stat_t cm_is_in_program_end_state(void);
 
 stat_t cm_json_command(char *json_string);                      // M100
 stat_t cm_json_command_immediate(char *json_string);            // M100.1

--- a/g2core/canonical_machine.h
+++ b/g2core/canonical_machine.h
@@ -55,6 +55,9 @@
 #define JERK_INPUT_MAX      (1000000)       // maximum allowable jerk setting in millions mm/min^3
 #define PROBES_STORED       3               // we store three probes for coordinate rotation computation
 #define MAX_LINENUM         2000000000      // set 2 billion as max line number
+#define BASE_STATE_SPINDLE_STOPPED 0
+#define BASE_STATE_MFO_FACTOR 1.0
+#define BASE_STATE_MTO_FACTOR 1.0
 
 /*****************************************************************************
  * MACHINE STATE MODEL

--- a/g2core/canonical_machine.h
+++ b/g2core/canonical_machine.h
@@ -475,7 +475,7 @@ void cm_canned_cycle_end(void);                                 // end of canned
 void cm_program_stop(void);                                     // M0
 void cm_optional_program_stop(void);                            // M1
 void cm_program_end(void);                                      // M2
-stat_t cm_is_in_program_end_state(void);
+stat_t cm_is_in_program_end_state(void);                        // Checks end status
 
 stat_t cm_json_command(char *json_string);                      // M100
 stat_t cm_json_command_immediate(char *json_string);            // M100.1

--- a/g2core/plan_zoid.cpp
+++ b/g2core/plan_zoid.cpp
@@ -142,10 +142,10 @@ stat_t mp_calculate_ramps(mpBlockRuntimeBuf_t* block, mpBuf_t* bf, const float e
     // handle overrides
     bf->override_factor = 1.0;
     if (bf->gm.motion_mode == MOTION_MODE_STRAIGHT_TRAVERSE) {
-        bf->override_factor = cm->gmx.mto_enable ? cm->gmx.mto_factor : 1.0;
+        bf->override_factor = cm->gmx.mto_enable ? cm->gmx.mto_factor : BASE_STATE_MTO_FACTOR;
     }
     else if ((bf->gm.motion_mode == MOTION_MODE_STRAIGHT_FEED) || (bf->gm.motion_mode == MOTION_MODE_CW_ARC) || (bf->gm.motion_mode == MOTION_MODE_CCW_ARC)) {
-        bf->override_factor = cm->gmx.mfo_enable ? cm->gmx.mfo_factor : 1.0;
+        bf->override_factor = cm->gmx.mfo_enable ? cm->gmx.mfo_factor : BASE_STATE_MFO_FACTOR;
     }
 
     // bf->cruise_vmax adjusted by override cannot go above absolute vmax,

--- a/g2core/planner.cpp
+++ b/g2core/planner.cpp
@@ -184,7 +184,7 @@ void planner_init(mpPlanner_t *_mp, mpPlannerRuntime_t *_mr, mpBuf_t *queue, uin
     memset(_mp, 0, sizeof(mpPlanner_t));    // clear all values, pointers and status
     _mp->magic_start = MAGICNUM;            // set boundary condition assertions
     _mp->magic_end = MAGICNUM;
-    _mp->mfo_factor = 1.00;
+    _mp->mfo_factor = BASE_STATE_MFO_FACTOR;
 
     // init planner queues
     _mp->q.bf = queue;                      // assign puffer pool to queue manager structure

--- a/g2core/planner.cpp
+++ b/g2core/planner.cpp
@@ -394,9 +394,7 @@ static stat_t _exec_command(mpBuf_t *bf)
 stat_t mp_runtime_command(mpBuf_t *bf) {
     bf->cm_func(bf->unit, bf->axis_flags);          // 2 vectors used by callbacks
     if (mp_free_run_buffer()) {
-        if (cm_is_in_program_end_state()) {
-            cm_cycle_end(true);
-        }
+        if (cm_is_in_program_end_state()) { cm_cycle_end(true); } // Checking for an M2/M30 at EOF
         else { cm_cycle_end(); }
     }
     return (STAT_OK);

--- a/g2core/planner.cpp
+++ b/g2core/planner.cpp
@@ -394,7 +394,10 @@ static stat_t _exec_command(mpBuf_t *bf)
 stat_t mp_runtime_command(mpBuf_t *bf) {
     bf->cm_func(bf->unit, bf->axis_flags);          // 2 vectors used by callbacks
     if (mp_free_run_buffer()) {
-        cm_cycle_end(true);                         // free buffer & perform cycle_end if planner is empty
+        if (cm_is_in_program_end_state()) {
+            cm_cycle_end(true);
+        }
+        else { cm_cycle_end(); }
     }
     return (STAT_OK);
 }

--- a/g2core/planner.cpp
+++ b/g2core/planner.cpp
@@ -391,11 +391,10 @@ static stat_t _exec_command(mpBuf_t *bf)
     return (STAT_OK);
 }
 
-stat_t mp_runtime_command(mpBuf_t *bf)
-{
+stat_t mp_runtime_command(mpBuf_t *bf) {
     bf->cm_func(bf->unit, bf->axis_flags);          // 2 vectors used by callbacks
     if (mp_free_run_buffer()) {
-        cm_cycle_end();                             // free buffer & perform cycle_end if planner is empty
+        cm_cycle_end(true);                         // free buffer & perform cycle_end if planner is empty
     }
     return (STAT_OK);
 }

--- a/g2core/spindle.cpp
+++ b/g2core/spindle.cpp
@@ -70,7 +70,7 @@ void spindle_reset() {
 
 void spindle_stop() {
     cm->gm.spindle_direction = SPINDLE_OFF;
-    cm->gm.spindle_speed = 0;
+    cm->gm.spindle_speed = BASE_STATE_SPINDLE_STOPPED;
     if (active_toolhead) {
         active_toolhead->stop();
     }


### PR DESCRIPTION
This fixes the issue of stat:4 not being displayed when a M30 or M2 is at the end of a file. With Rob G's help a simpler way to fix the problem was found. Though it does introduce some odd (but hopefully acceptable) behavior.

Effectively, ANY "M" command at the end of a file will now trigger a stat:4. Not just M2/M30. This was done because to make it just them would require a lot more work according to Rob G. If this is acceptable, then the problem is fixed!