### PR TITLE
Main item 25 spindle turns off prematurely in feedhold

### DIFF
--- a/g2core/cycle_feedhold.cpp
+++ b/g2core/cycle_feedhold.cpp
@@ -836,6 +836,7 @@ stat_t _feedhold_with_actions()          // Execute Case (5)
                 cm_set_distance_mode(cm1.gm.distance_mode);         // restore distance mode to p1 setting
             }
         }
+        coolant_control_sync(COOLANT_PAUSE, COOLANT_BOTH);  // optional coolant pause
         mp_queue_command(_feedhold_actions_done_callback, nullptr, nullptr);
         return (STAT_EAGAIN);
     }
@@ -849,7 +850,6 @@ stat_t _feedhold_with_actions()          // Execute Case (5)
     if ((cm1.hold_state == FEEDHOLD_HOLD_ACTIONS_COMPLETE) || (cm1.hold_state == FEEDHOLD_HOLD)) {
         cm1.hold_state = FEEDHOLD_HOLD;
         spindle_pause();                    // optional spindle pause
-        coolant_control_sync(COOLANT_PAUSE, COOLANT_BOTH);      // optional coolant pause
         
         return (STAT_OK);
     }

--- a/g2core/cycle_feedhold.cpp
+++ b/g2core/cycle_feedhold.cpp
@@ -836,8 +836,6 @@ stat_t _feedhold_with_actions()          // Execute Case (5)
                 cm_set_distance_mode(cm1.gm.distance_mode);         // restore distance mode to p1 setting
             }
         }
-        spindle_pause();                                        // optional spindle pause
-        coolant_control_sync(COOLANT_PAUSE, COOLANT_BOTH);      // optional coolant pause
         mp_queue_command(_feedhold_actions_done_callback, nullptr, nullptr);
         return (STAT_EAGAIN);
     }
@@ -850,6 +848,9 @@ stat_t _feedhold_with_actions()          // Execute Case (5)
     // finalize feedhold entry after callback OR skipping actions (this is needed so we can return STAT_OK)
     if ((cm1.hold_state == FEEDHOLD_HOLD_ACTIONS_COMPLETE) || (cm1.hold_state == FEEDHOLD_HOLD)) {
         cm1.hold_state = FEEDHOLD_HOLD;
+        spindle_pause();                    // optional spindle pause
+        coolant_control_sync(COOLANT_PAUSE, COOLANT_BOTH);      // optional coolant pause
+        
         return (STAT_OK);
     }
     return (STAT_EAGAIN);                   // keep the compiler happy. Never executed.

--- a/g2core/spindle.cpp
+++ b/g2core/spindle.cpp
@@ -89,6 +89,7 @@ void spindle_resume() {
 // A command for placing in the queue, which forces a PTS (plan-to-stop) as well as calls active_toolhead->engage()
 static void _exec_spindle_control(float *, bool *) {
     // not really anything to do here - engage() should have just been called
+    mp_request_out_of_band_dwell(3);
 }
 
 stat_t spindle_set_speed(float speed) {

--- a/g2core/spindle.cpp
+++ b/g2core/spindle.cpp
@@ -89,7 +89,6 @@ void spindle_resume() {
 // A command for placing in the queue, which forces a PTS (plan-to-stop) as well as calls active_toolhead->engage()
 static void _exec_spindle_control(float *, bool *) {
     // not really anything to do here - engage() should have just been called
-    mp_request_out_of_band_dwell(3);
 }
 
 stat_t spindle_set_speed(float speed) {


### PR DESCRIPTION
This should fix issue #25 where the spindle is not waiting for the Z-lift to complete or at least begin before turning off when a feedhold is initiated.
Timings look good in SR's, but someone with a physical spindle should test and confirm.