### PR TITLE
Main item 24 feedhold resume displays out1 aka spindle in sr after dwell

### DIFF
--- a/g2core/cycle_feedhold.cpp
+++ b/g2core/cycle_feedhold.cpp
@@ -900,6 +900,8 @@ stat_t _feedhold_restart_with_actions()   // Execute Cases (6) and (7)
         cm_goto_g30_position_mm(cm2.gmx.g30_position, cm2.return_flags);
         mp_queue_command(_feedhold_restart_actions_done_callback, nullptr, nullptr);
         cm1.hold_state = FEEDHOLD_EXIT_ACTIONS_PENDING;
+        sr_request_status_report(SR_REQUEST_IMMEDIATE);
+        
         return (STAT_EAGAIN);
     }
 

--- a/g2core/report.cpp
+++ b/g2core/report.cpp
@@ -167,30 +167,24 @@ void rpt_print_system_ready_message(void)
  */
 static stat_t _populate_unfiltered_status_report(void);
 static uint8_t _populate_filtered_status_report(void);
+static bool _position_equals_target(char*);
 
-uint8_t _is_stat(nvObj_t *nv)
-{
+bool _position_equals_target(char *sr_token) {
+
     char token[TOKEN_LEN+1];
 
-    GET_TOKEN_STRING(nv->value_int, token);   // pass in index, get back token
-    if (strcmp(token, "stat") == 0) { return (true);}
-    return (false);
-}
+    // Check for a valid position axis, then compare position and target at specified axis
+    strcpy(token, sr_token);
 
-uint8_t _pos_token_to_axis(nvObj_t *nv)
-{
-    char token[TOKEN_LEN+1];
-    strcpy(token, nv->token);
+    if (strcmp(token, "x") == 0) { return (fp_EQ(cm->gmx.position[AXIS_X], cm->gm.target[AXIS_X]));}
+    if (strcmp(token, "y") == 0) { return (fp_EQ(cm->gmx.position[AXIS_Y], cm->gm.target[AXIS_Y]));}
+    if (strcmp(token, "z") == 0) { return (fp_EQ(cm->gmx.position[AXIS_Z], cm->gm.target[AXIS_Z]));}
+    if (strcmp(token, "a") == 0) { return (fp_EQ(cm->gmx.position[AXIS_A], cm->gm.target[AXIS_A]));}
+    if (strcmp(token, "b") == 0) { return (fp_EQ(cm->gmx.position[AXIS_B], cm->gm.target[AXIS_B]));}
+    if (strcmp(token, "c") == 0) { return (fp_EQ(cm->gmx.position[AXIS_C], cm->gm.target[AXIS_C]));}
 
-    //GET_TOKEN_STRING(nv->index, token);   // pass in index, get back token
-    if (strcmp(token, "x") == 0) { return (AXIS_X);}
-    if (strcmp(token, "y") == 0) { return (AXIS_Y);}
-    if (strcmp(token, "z") == 0) { return (AXIS_Z);}
-    if (strcmp(token, "a") == 0) { return (AXIS_A);}
-    if (strcmp(token, "b") == 0) { return (AXIS_B);}
-    if (strcmp(token, "c") == 0) { return (AXIS_C);}
-    
-    return 99;  // should never get here
+    // Invalid axis, return
+    return false;
 }
 
 /*
@@ -494,7 +488,7 @@ static uint8_t _populate_filtered_status_report()
         // ignore position (pos) when start point = end point and we're in cycle
         // since cm_update_model_position can cause false position SRs
         if ((strcmp(sr.status_report_list[i].group, "pos") == 0) && (mp == &mp2) && 
-            (fp_EQ(cm->gmx.position[_pos_token_to_axis(nv)], cm->gm.target[_pos_token_to_axis(nv)])) &&
+            (_position_equals_target(sr.status_report_list[i].token)) &&
             (cm->machine_state == MACHINE_CYCLE)) {
             
             changed = false;

--- a/g2core/report.cpp
+++ b/g2core/report.cpp
@@ -170,21 +170,10 @@ static uint8_t _populate_filtered_status_report(void);
 static bool _position_equals_target(char*);
 
 bool _position_equals_target(char *sr_token) {
-
-    char token[TOKEN_LEN+1];
-
     // Check for a valid position axis, then compare position and target at specified axis
-    strcpy(token, sr_token);
-
-    if (strcmp(token, "x") == 0) { return (fp_EQ(cm->gmx.position[AXIS_X], cm->gm.target[AXIS_X]));}
-    if (strcmp(token, "y") == 0) { return (fp_EQ(cm->gmx.position[AXIS_Y], cm->gm.target[AXIS_Y]));}
-    if (strcmp(token, "z") == 0) { return (fp_EQ(cm->gmx.position[AXIS_Z], cm->gm.target[AXIS_Z]));}
-    if (strcmp(token, "a") == 0) { return (fp_EQ(cm->gmx.position[AXIS_A], cm->gm.target[AXIS_A]));}
-    if (strcmp(token, "b") == 0) { return (fp_EQ(cm->gmx.position[AXIS_B], cm->gm.target[AXIS_B]));}
-    if (strcmp(token, "c") == 0) { return (fp_EQ(cm->gmx.position[AXIS_C], cm->gm.target[AXIS_C]));}
-
-    // Invalid axis, return
-    return false;
+    if (strcmp(sr_token, "z") == 0) { return (fp_EQ(cm->gmx.position[AXIS_Z], cm->gm.target[AXIS_Z])); } 
+        
+    return false; // Invalid axis, return
 }
 
 /*
@@ -476,23 +465,22 @@ static uint8_t _populate_filtered_status_report()
             }
         } else {
             auto current_value_int = nv->value_int;
-            if (((nv->index == sr.stat_index) &&
-                    ((current_value_int == COMBINED_PROGRAM_STOP) || (current_value_int == COMBINED_PROGRAM_END))) ||
-                (current_value_int != (decltype(current_value_int))sr.status_report_list[i].value)) {
+            if (((nv->index == sr.stat_index) && ((current_value_int == COMBINED_PROGRAM_STOP) || (current_value_int == COMBINED_PROGRAM_END))) || 
+               (current_value_int != (decltype(current_value_int))sr.status_report_list[i].value)) {
+                
                 changed = true;
                 current_value = current_value_int;
             }
-        }   
+        }
         
-        // TODO: cleanup / move this
-        // ignore position (pos) when start point = end point and we're in cycle
+        // Ignore position (pos) when the start point = end point and we're in a cycle
         // since cm_update_model_position can cause false position SRs
-        if (changed &&                                                      // SR flagged for update
-            (strcmp(sr.status_report_list[i].group, "pos") == 0) &&         // position (pos) report
-            (_position_equals_target(sr.status_report_list[i].token)) &&    // target = position 
-            (mp == &mp2) &&                                                 // using secondary planner (feedhold)
-            (cm_get_machine_state() == MACHINE_CYCLE) &&                    // in a cycle
-            (cm_get_motion_state() == MOTION_STOP)) {                       // currently stopped (in MODEL runtime)
+        if (changed                                                         // SR flagged for update
+            && (mp == &mp2)                                                 // using secondary planner (feedhold)
+            && (strcmp(sr.status_report_list[i].group, "pos") == 0)         // position (pos) report
+            && (_position_equals_target(sr.status_report_list[i].token))    // target = position 
+            && (cm_get_machine_state() == MACHINE_CYCLE)                    // in a cycle
+            && (cm_get_motion_state() == MOTION_STOP)) {                    // currently stopped (in MODEL runtime)
             
             changed = false;
         }
@@ -505,7 +493,7 @@ static uint8_t _populate_filtered_status_report()
             sr.status_report_list[i].value = current_value;
 
             if ((nv = nv->nx) == NULL) {        // should never be NULL unless SR length exceeds available buffer array
-            return (false);
+                return (false);
             }
             has_data = true;
         } else {

--- a/g2core/report.cpp
+++ b/g2core/report.cpp
@@ -487,9 +487,12 @@ static uint8_t _populate_filtered_status_report()
         // TODO: cleanup / move this
         // ignore position (pos) when start point = end point and we're in cycle
         // since cm_update_model_position can cause false position SRs
-        if ((strcmp(sr.status_report_list[i].group, "pos") == 0) && (mp == &mp2) && 
-            (_position_equals_target(sr.status_report_list[i].token)) &&
-            (cm->machine_state == MACHINE_CYCLE)) {
+        if (changed &&                                                      // SR flagged for update
+            (strcmp(sr.status_report_list[i].group, "pos") == 0) &&         // position (pos) report
+            (_position_equals_target(sr.status_report_list[i].token)) &&    // target = position 
+            (mp == &mp2) &&                                                 // using secondary planner (feedhold)
+            (cm_get_machine_state() == MACHINE_CYCLE) &&                    // in a cycle
+            (cm_get_motion_state() == MOTION_STOP)) {                       // currently stopped (in MODEL runtime)
             
             changed = false;
         }

--- a/g2core/report.cpp
+++ b/g2core/report.cpp
@@ -180,15 +180,16 @@ uint8_t _is_stat(nvObj_t *nv)
 uint8_t _pos_token_to_axis(nvObj_t *nv)
 {
     char token[TOKEN_LEN+1];
+    strcpy(token, nv->token);
 
-    GET_TOKEN_STRING(nv->index, token);   // pass in index, get back token
+    //GET_TOKEN_STRING(nv->index, token);   // pass in index, get back token
     if (strcmp(token, "x") == 0) { return (AXIS_X);}
     if (strcmp(token, "y") == 0) { return (AXIS_Y);}
     if (strcmp(token, "z") == 0) { return (AXIS_Z);}
     if (strcmp(token, "a") == 0) { return (AXIS_A);}
     if (strcmp(token, "b") == 0) { return (AXIS_B);}
     if (strcmp(token, "c") == 0) { return (AXIS_C);}
-        
+    
     return 99;  // should never get here
 }
 
@@ -492,12 +493,12 @@ static uint8_t _populate_filtered_status_report()
         // TODO: cleanup / move this
         // ignore position (pos) when start point = end point and we're in cycle
         // since cm_update_model_position can cause false position SRs
-        if ((strcmp(sr.status_report_list[i].group, "pos") == 0) && 
+        if ((strcmp(sr.status_report_list[i].group, "pos") == 0) && (mp == &mp2) && 
             (fp_EQ(cm->gmx.position[_pos_token_to_axis(nv)], cm->gm.target[_pos_token_to_axis(nv)])) &&
             (cm->machine_state == MACHINE_CYCLE)) {
-                        
+            
             changed = false;
-        }            
+        }
 
         // report values that have changed by more than the indicated precision, but always stops and ends
         if (changed) {


### PR DESCRIPTION
This fixes the #24 spindle on/off reporting not occurring before the dwell. The initial fix also caused a instance of the "final position reported prematurely" issue, like what happens with Google Sheets issue 11 "incorrect location reports". 

Effectively we would get a SR at the right time, but which reported where Z was going to end up, not where it was. The changes to prevent that are all in report.cpp

The fix gave us a lot more insight into what may be causing the other issue, but unfortunately didn't end up fixing it as well.

Also one old function (_is_stat) that was not used anywhere in the code was deleted.