### PR TITLE
Main item 34 faulty SRs from feedhold or kill

### DIFF
--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -2245,7 +2245,7 @@ stat_t cm_get_vel(nvObj_t *nv)
 }
 
 stat_t cm_get_feed(nvObj_t *nv) { return (get_float(nv, cm_get_feed_rate(ACTIVE_MODEL))); }
-stat_t cm_get_pos(nvObj_t *nv)  { return (get_float(nv, cm_get_display_position(ACTIVE_MODEL, _axis(nv)))); }
+stat_t cm_get_pos(nvObj_t *nv)  { return (get_float(nv, cm_get_display_position(RUNTIME, _axis(nv)))); }
 ////## rob fix for erratic locations; fixes but breaks probe! stat_t cm_get_pos(nvObj_t *nv)  { return (get_float(nv, cm_get_display_position(ACTIVE_MODEL, _axis(nv)))); }
 stat_t cm_get_mpo(nvObj_t *nv)  { return (get_float(nv, cm_get_absolute_position(ACTIVE_MODEL, _axis(nv)))); }
 stat_t cm_get_ofs(nvObj_t *nv)  { return (get_float(nv, cm_get_display_offset(ACTIVE_MODEL, _axis(nv)))); }

--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -2246,7 +2246,6 @@ stat_t cm_get_vel(nvObj_t *nv)
 
 stat_t cm_get_feed(nvObj_t *nv) { return (get_float(nv, cm_get_feed_rate(ACTIVE_MODEL))); }
 stat_t cm_get_pos(nvObj_t *nv)  { return (get_float(nv, cm_get_display_position(RUNTIME, _axis(nv)))); }
-////## rob fix for erratic locations; fixes but breaks probe! stat_t cm_get_pos(nvObj_t *nv)  { return (get_float(nv, cm_get_display_position(ACTIVE_MODEL, _axis(nv)))); }
 stat_t cm_get_mpo(nvObj_t *nv)  { return (get_float(nv, cm_get_absolute_position(ACTIVE_MODEL, _axis(nv)))); }
 stat_t cm_get_ofs(nvObj_t *nv)  { return (get_float(nv, cm_get_display_offset(ACTIVE_MODEL, _axis(nv)))); }
 

--- a/g2core/plan_exec.cpp
+++ b/g2core/plan_exec.cpp
@@ -1041,7 +1041,7 @@ static stat_t _exec_aline_feedhold(mpBuf_t *bf)
             mr->reset();                                    // reset MR for next use and for forward planning
             cm_set_motion_state(MOTION_STOP);
             cm->hold_state = FEEDHOLD_MOTION_STOPPED;
-            //sr_request_status_report(SR_REQUEST_IMMEDIATE); // Causes faulty SR's for issue #11 when feedholding or killing
+            sr_request_status_report(SR_REQUEST_IMMEDIATE); // Causes faulty SR's for issue #11 when feedholding or killing
         }
         return (STAT_NOOP);                                 // hold here. leave with a NOOP so it does not attempt another load and exec.
     }

--- a/g2core/plan_exec.cpp
+++ b/g2core/plan_exec.cpp
@@ -1041,7 +1041,7 @@ static stat_t _exec_aline_feedhold(mpBuf_t *bf)
             mr->reset();                                    // reset MR for next use and for forward planning
             cm_set_motion_state(MOTION_STOP);
             cm->hold_state = FEEDHOLD_MOTION_STOPPED;
-            sr_request_status_report(SR_REQUEST_IMMEDIATE); // Causes faulty SR's for issue #11 when feedholding or killing
+            sr_request_status_report(SR_REQUEST_IMMEDIATE);
         }
         return (STAT_NOOP);                                 // hold here. leave with a NOOP so it does not attempt another load and exec.
     }

--- a/g2core/plan_exec.cpp
+++ b/g2core/plan_exec.cpp
@@ -1041,7 +1041,7 @@ static stat_t _exec_aline_feedhold(mpBuf_t *bf)
             mr->reset();                                    // reset MR for next use and for forward planning
             cm_set_motion_state(MOTION_STOP);
             cm->hold_state = FEEDHOLD_MOTION_STOPPED;
-            sr_request_status_report(SR_REQUEST_IMMEDIATE);
+            //sr_request_status_report(SR_REQUEST_IMMEDIATE); // Causes faulty SR's for issue #11 when feedholding or killing
         }
         return (STAT_NOOP);                                 // hold here. leave with a NOOP so it does not attempt another load and exec.
     }


### PR DESCRIPTION
This fixes the issue of incorrect SR's issue #34 displaying prematurely the target value instead of the current (actual) value when a feedhold or kill is issued.
The issue was best traced back to `cm_get_pos` getting called inside `_populate_filtered_status_report()`. It would pass in the `ACTIVE_MODEL` macro, which would sometimes be in the wrong context for pulling position values. Passing in the `RUNTIME` macro inside this one call to `cm_get_display_position` allows the `else` clause to trigger which runs `mp_get_runtime_display_position` and gets us the correct value.

All testing so far has proven this to be a working fix for the general SR issue in the old Google Sheets doc number 11. This also fixes the small Z-axis related error reintroduced in the fix for issue #24 PR #30. As this changes less and seems more elegant.

One potential issue with this fix is while things appear normal for `G1`'s and `G0`'s probes (`G38.3`) produce less SR's when a feedhold occurs. Previously you could expect 2-4 SRs to pop up after `!`. Now it's generally 1 sometimes 2.

Feedback is requested if having less SR's after feedholding in a probe is expected to be an issue?