### PR TITLE
Main item 22 m0 should not turn spindle off

### DIFF
--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -1748,8 +1748,10 @@ stat_t cm_m48_enable(uint8_t enable)        // M48, M49
 
 static void _exec_program_finalize(float* value, bool* flag) {
     // perform the following resets if it's a program END
-    if (flag != nullptr) {
-        spindle_stop();             // immediate M5
+    if (flag[0]) {
+    //if (flag != nullptr) {
+        //if (fp_EQ(*value, 1)) { spindle_stop(); }           // Turn spindle off only if M2/M30
+        if (flag[1]) { spindle_stop(); }           // Turn spindle off only if M2/M30
         coolant_control_immediate(COOLANT_OFF,COOLANT_BOTH);// immediate M9
         temperature_reset();                                // turn off all heaters and fans
         cm_reset_overrides();                               // enable G48, reset feed rate, traverse and spindle overrides
@@ -1770,12 +1772,17 @@ static void _exec_program_stop_end(cmMachineState machine_state)
         cm->machine_state = machine_state;                  // don't update macs/cycs if we're in the middle of a canned cycle,
     }
 
+    //static bool flag; // gives us an address to point to
+    static bool flag[2];
+    //float value = 0;
     // reset the rest of the states
     cm->hold_state = FEEDHOLD_OFF;
     // mp_zero_segment_velocity();                             // for reporting purposes
 
     // perform the following resets if it's a program END
     if (machine_state == MACHINE_PROGRAM_END) {
+        flag[0] = true, flag[1] = true;
+        //value = 1;
         cm_suspend_g92_offsets();                           //  G92.2 - as per NIST
         cm_set_coord_system(cm->default_coord_system);      //  reset to default coordinate system
         cm_select_plane(cm->default_select_plane);          //  reset to default arc plane
@@ -1788,8 +1795,9 @@ static void _exec_program_stop_end(cmMachineState machine_state)
     }
     cm_set_motion_state(MOTION_STOP);                       // also changes active model back to MODEL
 
-    static bool flag; // gives us an address to point to
-    mp_queue_command(_exec_program_finalize, nullptr, (machine_state == MACHINE_PROGRAM_END) ? &flag : nullptr);
+    //mp_queue_command(_exec_program_finalize, nullptr, (machine_state == MACHINE_PROGRAM_END) ? &flag : nullptr);
+    //mp_queue_command(_exec_program_finalize, (machine_state == MACHINE_PROGRAM_END) ? &(value = 1): nullptr, (machine_state == MACHINE_PROGRAM_END) ? &flag : nullptr);
+    mp_queue_command(_exec_program_finalize, nullptr, flag);
 }
 
 // Will start a cycle regardless of whether the planner has moves or not

--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -1774,7 +1774,7 @@ static void _exec_program_stop_end(cmMachineState machine_state)
     cm->hold_state = FEEDHOLD_OFF;
     // mp_zero_segment_velocity();                              //  for reporting purposes
 
-    static bool flag = false;                                //  M0/M2/M30 flag
+    bool flag = false;                                       //  M0/M2/M30 flag
     // perform the following resets if it's a program END
     if (machine_state == MACHINE_PROGRAM_END) {
         flag = true;                                         //  M2/M30


### PR DESCRIPTION
This should fix issue #22 . The spindle should no longer turn off when a `M0` **EDIT (/facepalm, Sorry! Only meant to say M2) EDIT** comes through. It seems a previous fix using null pointers was not working correctly and the pointer in question was still getting a "value" and thus not null. Probably because of the command queuing nature of G2 and it's `bf` struct.