### PR TITLE
Reduce precision in stepping runtime to improve performance

### DIFF
--- a/g2core/device/step_dir_driver/step_dir_driver.h
+++ b/g2core/device/step_dir_driver/step_dir_driver.h
@@ -85,9 +85,12 @@ struct StepDirStepper final : Stepper  {
     float _idle_power_level; // the power level when idle
     float _power_level; // the power level now
 
-    int64_t _step_count;
-    int64_t _step_count_up;
-    int64_t _step_count_down;
+////##th_prec    int64_t _step_count;
+////##th_prec    int64_t _step_count_up;
+////##th_prec    int64_t _step_count_down;
+    int32_t _step_count;
+    int32_t _step_count_up;
+    int32_t _step_count_down;
     uint8_t _step_dir;
 
     void _updatePowerLevel() {
@@ -243,15 +246,18 @@ struct StepDirStepper final : Stepper  {
     	    _step.clear();
     };
 
-    int64_t getStepCount() override {
+////##th_prec    int64_t getStepCount() override {
+    int32_t getStepCount() override {
         return _step_count;
     }
 
-    int64_t getStepCountUp() override {
+////##th_prec    int64_t getStepCountUp() override {
+    int32_t getStepCountUp() override {
         return _step_count_up;
     }
 
-    int64_t getStepCountDown() override {
+////##th_prec    int64_t getStepCountDown() override {
+    int32_t getStepCountDown() override {
         return _step_count_down;
     }
 

--- a/g2core/stepper.cpp
+++ b/g2core/stepper.cpp
@@ -759,7 +759,8 @@ stat_t st_prep_line(const float start_velocity, const float end_velocity, const 
 
     // setup motor parameters
     // this is explained later
-    double t_v0_v1 = (double)st_pre.dda_ticks * (start_velocity + end_velocity);
+////##th_prec    double t_v0_v1 = (double)st_pre.dda_ticks * (start_velocity + end_velocity);
+    float t_v0_v1 = (float)st_pre.dda_ticks * (start_velocity + end_velocity);
 
     for (uint8_t motor=0; motor<MOTORS; motor++) {          // remind us that this is motors, not axes
         float steps = travel_steps[motor];
@@ -839,15 +840,18 @@ stat_t st_prep_line(const float start_velocity, const float end_velocity, const 
         // option 2:
         //  d = (b (v_1 - v_0))/((t-1) a)
 
-        double s_double = std::abs(steps * 2.0);
+////##th_prec        double s_double = std::abs(steps * 2.0);
+        float s_double = std::abs(steps * 2.0);
 
         // 1/m_0 = (2 s v_0)/(t (v_0 + v_1))
-        st_pre.mot[motor].substep_increment = round(((s_double * start_velocity)/(t_v0_v1)) * (double)DDA_SUBSTEPS);
+////##th_prec        st_pre.mot[motor].substep_increment = round(((s_double * start_velocity)/(t_v0_v1)) * (double)DDA_SUBSTEPS);
+        st_pre.mot[motor].substep_increment = round(((s_double * start_velocity)/(t_v0_v1)) * (float)DDA_SUBSTEPS);
         // option 1:
         //  d = ((b v_1)/a - c)/(t-1)
         // option 2:
         //  d = (b (v_1 - v_0))/((t-1) a)
-        st_pre.mot[motor].substep_increment_increment = round(((s_double*(end_velocity-start_velocity))/(((double)st_pre.dda_ticks-1.0)*t_v0_v1)) * (double)DDA_SUBSTEPS);
+////##th_prec        st_pre.mot[motor].substep_increment_increment = round(((s_double*(end_velocity-start_velocity))/(((double)st_pre.dda_ticks-1.0)*t_v0_v1)) * (double)DDA_SUBSTEPS);
+        st_pre.mot[motor].substep_increment_increment = round(((s_double*(end_velocity-start_velocity))/(((float)st_pre.dda_ticks-1.0)*t_v0_v1)) * (float)DDA_SUBSTEPS);
     }
     st_pre.block_type = BLOCK_TYPE_ALINE;
     st_pre.bf = nullptr;
@@ -882,11 +886,14 @@ stat_t st_prep_line(const float start_velocities[], const float end_velocities[]
         float steps = travel_steps[motor];
 
         // setup motor parameters
-        double t_v0_v1 = (double)st_pre.dda_ticks * (start_velocities[motor] + end_velocities[motor]);
+////##th_prec        double t_v0_v1 = (double)st_pre.dda_ticks * (start_velocities[motor] + end_velocities[motor]);
+        float t_v0_v1 = (float)st_pre.dda_ticks * (start_velocities[motor] + end_velocities[motor]);
 
         // Skip this motor if there are no new steps. Leave all other values intact.
         if (fp_ZERO(steps)) {
             st_pre.mot[motor].substep_increment = 0;        // substep increment also acts as a motor flag
+////##th_prec should add this here too 
+            st_pre.mot[motor].substep_increment_increment = 0;        ////## added per RobG suggestion 09/08/22
             continue;
         }
 
@@ -920,10 +927,12 @@ stat_t st_prep_line(const float start_velocities[], const float end_velocities[]
         //// }
 
         // All math is explained in the previous function
-
-        double s_double = std::abs(steps * 2.0);
-        st_pre.mot[motor].substep_increment = round(((s_double * start_velocities[motor])/(t_v0_v1)) * (double)DDA_SUBSTEPS);
-        st_pre.mot[motor].substep_increment_increment = round(((s_double*(end_velocities[motor]-start_velocities[motor]))/(((double)st_pre.dda_ticks-1.0)*t_v0_v1)) * (double)DDA_SUBSTEPS);
+////##th_prec        double s_double = std::abs(steps * 2.0);
+////##th_prec        st_pre.mot[motor].substep_increment = round(((s_double * start_velocities[motor])/(t_v0_v1)) * (double)DDA_SUBSTEPS);
+////##th_prec        st_pre.mot[motor].substep_increment_increment = round(((s_double*(end_velocities[motor]-start_velocities[motor]))/(((double)st_pre.dda_ticks-1.0)*t_v0_v1)) * (double)DDA_SUBSTEPS);
+        float s_double = std::abs(steps * 2.0);
+        st_pre.mot[motor].substep_increment = round(((s_double * start_velocities[motor])/(t_v0_v1)) * (float)DDA_SUBSTEPS);
+        st_pre.mot[motor].substep_increment_increment = round(((s_double*(end_velocities[motor]-start_velocities[motor]))/(((float)st_pre.dda_ticks-1.0)*t_v0_v1)) * (float)DDA_SUBSTEPS);
     }
     st_pre.block_type = BLOCK_TYPE_ALINE;
     st_pre.bf = nullptr;

--- a/g2core/stepper.h
+++ b/g2core/stepper.h
@@ -363,9 +363,12 @@ typedef struct stConfig {                   // stepper configs
 // Motor runtime structure. Used exclusively by step generation ISR (HI)
 
 typedef struct stRunMotor {                 // one per controlled motor
-    int64_t substep_increment;             // partial steps to increment substep_accumulator per tick
-    int64_t substep_increment_increment;   // partial steps to increment substep_increment per tick
-    int64_t substep_accumulator;            // DDA phase angle accumulator
+////##th_prec    int64_t substep_increment;             // partial steps to increment substep_accumulator per tick
+////##th_prec    int64_t substep_increment_increment;   // partial steps to increment substep_increment per tick
+////##th_prec    int64_t substep_accumulator;            // DDA phase angle accumulator
+    int32_t substep_increment;             // partial steps to increment substep_accumulator per tick
+    int32_t substep_increment_increment;   // partial steps to increment substep_increment per tick
+    int32_t substep_accumulator;            // DDA phase angle accumulator
     bool motor_flag;                        // true if motor is participating in this move
     bool start_new_block;                   ////## to be used in run and prep ??
     uint32_t power_systick;                 // sys_tick for next motor power state transition
@@ -384,8 +387,10 @@ typedef struct stRunSingleton {             // Stepper static values and axis pa
 // Must be careful about volatiles in this one
 
 typedef struct stPrepMotor {
-    int64_t substep_increment;             // partial steps to increment substep_accumulator per tick
-    int64_t substep_increment_increment;   // partial steps to increment substep_increment per tick
+////##th_prec    int64_t substep_increment;             // partial steps to increment substep_accumulator per tick
+////##th_prec    int64_t substep_increment_increment;   // partial steps to increment substep_increment per tick
+    int32_t substep_increment;             // partial steps to increment substep_accumulator per tick
+    int32_t substep_increment_increment;   // partial steps to increment substep_increment per tick
     bool motor_flag;                        // true if motor is participating in this move
 
 ////## Block Initialization Marker          // Used to set initial SUSBSTEP_HALF_DDA in a block to make moves symetrical
@@ -510,9 +515,12 @@ public:
     virtual void _disableImpl() { /* must override */ };
     virtual void stepStart() HOT_FUNC { /* must override */ }; // HOT - called from the DDA interrupt
     virtual void stepEnd() HOT_FUNC { /* must override */ };   // HOT - called from the DDA interrupt
-    virtual int64_t getStepCount() { return 0; };
-    virtual int64_t getStepCountUp() { return 0; };
-    virtual int64_t getStepCountDown() { return 0; };
+////##th_prec    virtual int64_t getStepCount() { return 0; };
+////##th_prec    virtual int64_t getStepCountUp() { return 0; };
+////##th_prec    virtual int64_t getStepCountDown() { return 0; };
+    virtual int32_t getStepCount() { return 0; };
+    virtual int32_t getStepCountUp() { return 0; };
+    virtual int32_t getStepCountDown() { return 0; };
     virtual void resetStepCounts() { /* must override */ };
     virtual void setDirection(uint8_t direction) HOT_FUNC { /* must override */ }; // HOT - called from the DDA interrupt
     virtual void setMicrosteps(const uint16_t microsteps) { /* must override */ };

--- a/g2core/stepper.h
+++ b/g2core/stepper.h
@@ -306,7 +306,8 @@ enum stPowerMode {
  *  The ARM is roughly the same as the DDA clock rate is 4x higher but the segment time is ~1/5
  *  Decreasing the nominal segment time increases the number precision.
  */
- #define DDA_SUBSTEPS (INT64_MAX-100)
+////##th_prec #define DDA_SUBSTEPS (INT64_MAX-100) NOTE: reversion actually makes preceeding description right
+ #define DDA_SUBSTEPS (2147483600L)
  #define DDA_HALF_SUBSTEPS (DDA_SUBSTEPS/2)
 
 /* Step correction settings


### PR DESCRIPTION
Reduces double precision to single and int64s to int32s. Don't know how much is specifically required, but tried to make this all consistent. It eliminated a significant disruption in stepping that was observed when the clock speed was increased without the change.

This is actually a reversion in G2. Higher precision was applied several years back in an attempt to eliminate the Step/Encoder errors that were occurring. As we no longer have these errors, seemed reasonable.