### PR TITLE
Increased FREQUENCY_DDA to 150000 and moved location of secondary ste…

### DIFF
--- a/g2core/board/sbv300/hardware.h
+++ b/g2core/board/sbv300/hardware.h
@@ -118,11 +118,11 @@ using Motate::OutputPin;
 
 /**** Stepper DDA and dwell timer settings ****/
 
-//#define FREQUENCY_DDA		200000UL		// Hz step frequency. Interrupts actually fire at 2x (400 KHz)
-//#define FREQUENCY_DDA		150000UL		// Hz step frequency. Interrupts actually fire at 2x (300 KHz) ////**Used in previous FabMo
-#define FREQUENCY_DDA     100000UL        // Hz step frequency. Interrupts actually fire at 2x (200 KHz) *Speed of other boards! ////** Reverted for E-P test fix
-////## This in 101.03 versions #define FREQUENCY_SGI       200000UL        // 200,000 Hz means software interrupts will fire 5 uSec after being called
-////## But setting to 100000UL seemed to fix stuttering in 101.06 variants ...
+#define FREQUENCY_DDA		150000UL		// Hz step frequency. Interrupts actually fire at 2x (300 KHz) ////**Used in previous FabMo
+//#define FREQUENCY_DDA     100000UL        // Hz step frequency. Interrupts actually fire at 2x (200 KHz) *Speed of many other boards! 
+// 200,000 Hz means software interrupts will fire 5 uSec after being called
+////##th We used FREQUENCY_DDA of 100000 in early E-P work because of stutters going any faster; this fixed by reversion to single precision
+////## Make sure the secondary 'turn-off' of steps in stepper.cpp: _load_move is located appropriately for FREQUENCY_DDA selection
 
 #define FREQUENCY_DWELL		1000UL
 #define MIN_SEGMENT_MS ((float)1.0)        ////## tried shorter, default =.75 tried .5; did not seem to work

--- a/g2core/stepper.cpp
+++ b/g2core/stepper.cpp
@@ -476,28 +476,6 @@ static void _load_move()
     // Be aware that dda_ticks_downcount must equal zero for the loader to run.
     // So the initial load must also have this set to zero as part of initialization
 
-    ////## Test additional step-pin turn-off here to clean up large pulse (~20uS) when coincident with segment change
-    //       -probably need a better method; placed here the contingent pulse becomes ~3.4uS or ~7uS
-    //       -placed after st_runtime_isBusy(); contingent pulse becomes ~6.3uS or ~10uS
-    //       -and place after the segment loading work below it becomes ~7uS or ~16uS
-    //       ## I'm testing this out for a bit .... (all values above are for DDA_FREQ 100K)
-    //       ### There is still a very rare 20uS and 16uS pulse unrelated to segment or anything else obvious
-        motor_1.stepEnd();
-        motor_2.stepEnd();
-#if MOTORS > 2
-        motor_3.stepEnd();
-#endif
-#if MOTORS > 3
-        motor_4.stepEnd();
-#endif
-#if MOTORS > 4
-        motor_5.stepEnd();
-#endif
-#if MOTORS > 5
-        motor_6.stepEnd();
-#endif
-
-
     if (st_runtime_isbusy()) {
         return;                     // exit if the runtime is busy
     }
@@ -540,8 +518,27 @@ static void _load_move()
 
         //**** setup the new segment ****
 
+////## Secondary step-pin turn-off here to clean up large pulse (~20uS) when pulse coincident with segment load
+// * POSITION HERE for FREQUENCY_DDA = 150000
+// # There is still a rare ~16-20uS and 16uS pulse unrelated to segment or anything else obvious
+    motor_1.stepEnd();
+    motor_2.stepEnd();
+#if MOTORS > 2
+    motor_3.stepEnd();
+#endif
+#if MOTORS > 3
+    motor_4.stepEnd();
+#endif
+#if MOTORS > 4
+    motor_5.stepEnd();
+#endif
+#if MOTORS > 5
+    motor_6.stepEnd();
+#endif
+
         // st_run.dda_ticks_downcount is setup right before turning on the interrupt, since we don't turn it off
         // INLINED VERSION: 4.3us
+
         //**** MOTOR_1 LOAD ****
 
         // These sections are somewhat optimized for execution speed. The whole load operation
@@ -555,10 +552,6 @@ static void _load_move()
 
             // Prepare the substep increment increment for linear velocity ramping
             st_run.mot[MOTOR_1].substep_increment_increment = st_pre.mot[MOTOR_1].substep_increment_increment;
-
-            // Detect direction change and if so:
-            //    Set the direction bit in hardware.
-            //    Compensate for direction change by flipping substep accumulator value about its midpoint.
 
 ////##* Check for start of NEW BLOCK here and routinely set all directions for consistent time [WE ARE NO LONGER USING DIRECTION CHANGE TEST]
             if (st_pre.mot[MOTOR_1].start_new_block) {
@@ -693,8 +686,25 @@ static void _load_move()
         ACCUMULATE_ENCODER(MOTOR_6);
 #endif
 
-        //**** do this last ****
+////## Secondary step-pin turn-off here to clean up large pulse (~20uS) when pulse coincident with segment load
+//    * POSITION HERE for FREQUENCY_DDA = 100000
+//    # There is still a rare ~16-20uS and 16uS pulse unrelated to segment or anything else obvious
+//    motor_1.stepEnd();
+//    motor_2.stepEnd();
+// #if MOTORS > 2
+//    motor_3.stepEnd();
+// #endif
+// #if MOTORS > 3
+//    motor_4.stepEnd();
+// #endif
+// #if MOTORS > 4
+//    motor_5.stepEnd();
+// #endif
+// #if MOTORS > 5
+//    motor_6.stepEnd();
+// #endif
 
+        //**** do this last ****
         st_run.dda_ticks_downcount = st_pre.dda_ticks;
 
     // handle dwells and commands
@@ -857,6 +867,7 @@ stat_t st_prep_line(const float start_velocity, const float end_velocity, const 
 }
 
 // same as previous function, except it takes a different start and end velocity per motor
+////##th NOTE re:FabMo  : I believe this version of the function is only used by Four-Cable Kinematics. Do we want it?
 stat_t st_prep_line(const float start_velocities[], const float end_velocities[], const float travel_steps[], const float following_error[], const float segment_time)
 {
     // TODO refactor out common parts of the two st_prep_line functions

--- a/g2core/stepper.h
+++ b/g2core/stepper.h
@@ -300,28 +300,27 @@ enum stPowerMode {
  *    MAX_LONG == 2^31, maximum signed long (depth of accumulator. NB: accumulator values are negative)
  *    FREQUENCY_DDA == DDA clock rate in Hz.
  *    NOM_SEGMENT_TIME == upper bound of segment time in minutes
- *    0.90 == a safety factor used to reduce the result from theoretical maximum
+ *    0.90 == a safety factor used to reduce the result from theoretical maximum ////##th I can't find where this is used ???
  *
- *  The number is about 8.5 million for the Xmega running a 50 KHz DDA with 5 millisecond segments
- *  The ARM is roughly the same as the DDA clock rate is 4x higher but the segment time is ~1/5
- *  Decreasing the nominal segment time increases the number precision.
  */
- #define DDA_SUBSTEPS (INT64_MAX-100)
+////##th_prec #define DDA_SUBSTEPS (INT64_MAX-100) NOTE: reversion actually makes preceeding description right; last paragraph distracting
+ #define DDA_SUBSTEPS (2147483600L)
  #define DDA_HALF_SUBSTEPS (DDA_SUBSTEPS/2)
 
-/* Step correction settings
- *
- *  Step correction settings determine how the encoder error is fed back to correct position errors.
- *  Since the following_error is running 2 segments behind the current segment you have to be careful
- *  not to overcompensate. The threshold determines if a correction should be applied, and the factor
- *  is how much. The holdoff is how many segments to wait before applying another correction. If threshold
- *  is too small and/or amount too large and/or holdoff is too small you may get a runaway correction
- *  and error will grow instead of shrink (or oscillate).
- */
-#define STEP_CORRECTION_THRESHOLD   (float)2.00     // magnitude of forwarding error to apply correction (in steps)
-#define STEP_CORRECTION_FACTOR      (float)0.25     // factor to apply to step correction for a single segment
-#define STEP_CORRECTION_MAX         (float)0.60     // max step correction allowed in a single segment
-#define STEP_CORRECTION_HOLDOFF            5        // minimum number of segments to wait between error correction
+////##th OBSOLETE (remove?)
+// /* Step correction settings
+//  *
+//  *  Step correction settings determine how the encoder error is fed back to correct position errors.
+//  *  Since the following_error is running 2 segments behind the current segment you have to be careful
+//  *  not to overcompensate. The threshold determines if a correction should be applied, and the factor
+//  *  is how much. The holdoff is how many segments to wait before applying another correction. If threshold
+//  *  is too small and/or amount too large and/or holdoff is too small you may get a runaway correction
+//  *  and error will grow instead of shrink (or oscillate).
+//  */
+// #define STEP_CORRECTION_THRESHOLD   (float)2.00     // magnitude of forwarding error to apply correction (in steps)
+// #define STEP_CORRECTION_FACTOR      (float)0.25     // factor to apply to step correction for a single segment
+// #define STEP_CORRECTION_MAX         (float)0.60     // max step correction allowed in a single segment
+// #define STEP_CORRECTION_HOLDOFF            5        // minimum number of segments to wait between error correction
 
 /*
  * Stepper control structures


### PR DESCRIPTION
…pEnd in _load_move.

For improved performance to work, the previous two PR's on pulse_size and reduce_precision need to be in place

THIS is the THIRD of the 3 Step Performance improving PR's. It changes the speed and moves the location of PR#1's endSteps to refine the size of short pulses occurring with a new segment.

At whichever speed we use, there remains the occasion long pulse that occurs at intervals of many seconds. The max pulse size is about 21uS at 100000 and about 19uS at 150000. The pulse is seen the duration of the inter-step interval in all axes (e.g. time is added whether in a step or not).

The branch th_full_pulse_timing_precision is my complete version of all these changes.

As usual, you can identify changes and notes to reviewers/developers by the "////##th" marks. Feel free to remove any that are extraneous.  