### PR TITLE
Adding compile time guards to the instrumentation on motor 5

### DIFF
--- a/g2core/cycle_feedhold.cpp
+++ b/g2core/cycle_feedhold.cpp
@@ -410,7 +410,14 @@ void cm_request_cycle_start()
 ////##ted, cleanly starting a new block here ... ck this out
             cm_cycle_start();
 
-            motor_5.stepStart();             ////##temp diagnositc (uncomment to enable) START-NEW-BLOCK "planned" diagnostic indicator
+#ifdef INSTRUMENT_SEGMENTS_N_MOVES
+    // The above define should always be provided by through the make command line and never defined in the code
+    // we do not want the following code to ever appear in a customer release. It is diagnostic code for use
+    // with LogicAnalyzer. It outputs a step on the A axis at the beginning of a segment in the realtime state
+    // machine
+    // make CONFIG=sbv300 USER_DEFINES=INSTRUMENT_SEGMENTS_N_MOVES
+            motor_5.stepStart();
+#endif
 
         ////##* SET UP TO START_NEW_BLOCK ... right place? ... needed on all motors?
         for (uint8_t motor=0; motor<MOTORS; motor++) { 
@@ -962,7 +969,15 @@ stat_t _run_restart_cycle(void)
     if (mp_has_runnable_buffer(&mp1)) {
 
         cm_cycle_start();
-        motor_5.stepStart();             ////## marking (uncomment to enable) START-NEW-BLOCK "planned" diagnostic indicator
+
+#ifdef INSTRUMENT_SEGMENTS_N_MOVES
+    // The above define should always be provided by through the make command line and never defined in the code
+    // we do not want the following code to ever appear in a customer release. It is diagnostic code for use
+    // with LogicAnalyzer. It outputs a step on the A axis at the beginning of a segment in the realtime state
+    // machine
+    // make CONFIG=sbv300 USER_DEFINES=INSTRUMENT_SEGMENTS_N_MOVES
+        motor_5.stepStart();
+#endif
 
         ////##* SET UP TO START_NEW_BLOCK ... right place? ... needed on all motors?
         for (uint8_t motor=0; motor<MOTORS; motor++) { 

--- a/g2core/plan_exec.cpp
+++ b/g2core/plan_exec.cpp
@@ -469,7 +469,14 @@ stat_t mp_exec_aline(mpBuf_t *bf)
             }
         }
 
-        motor_5.stepStart();             ////## (uncomment to enable) START-NEW-BLOCK "planned" diagnostic indicator
+#ifdef INSTRUMENT_SEGMENTS_N_MOVES
+    // The above define should always be provided by through the make command line and never defined in the code
+    // we do not want the following code to ever appear in a customer release. It is diagnostic code for use
+    // with LogicAnalyzer. It outputs a step on the A axis at the beginning of a segment in the realtime state
+    // machine
+    // make CONFIG=sbv300 USER_DEFINES=INSTRUMENT_SEGMENTS_N_MOVES
+        motor_5.stepStart();
+#endif
 
         ////##* SET UP TO START_NEW_BLOCK ... right place? ... needed on all motors (maybe just a 'st_pre' flag)?
         for (uint8_t motor=0; motor<MOTORS; motor++) { 


### PR DESCRIPTION
missed this the first time through

Ran the normal dev checks on the vanilla build. Built it with the flag in place for the instrumented build. Built cleanly. Did not put a scope on it for the instrumented build to catch the 5th axis. Did run the preprocessor and inspect the output for cycle_feedhold.cpp and plan_exec.cpp. It is correctly present and the build succeeds. seems sufficient proof since we've been using this for weeks.
Kyle if you feel I need to do that let me know. I left my scope in the office so can't check it until I get back in.

This is just adding protection to a few more lines of code. 
The build is either
make CONFIG=sbv300
as normal or as instrumented use:
make CONFIG=sbv300 USER_DEFINES=INSTRUMENT_SEGMENTS_N_MOVES