### PR TITLE
Fix for motion problem with arcs that are too small

### DIFF
--- a/g2core/g2core.cppproj
+++ b/g2core/g2core.cppproj
@@ -22,7 +22,7 @@
     <eraseonlaunchrule>1</eraseonlaunchrule>
     <AsfVersion>3.5.0</AsfVersion>
     <avrtoolinterface>JTAG</avrtoolinterface>
-    <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
+    <avrtool>com.atmel.avrdbg.tool.samice</avrtool>
     <com_atmel_avrdbg_tool_samice>
       <ToolType>com.atmel.avrdbg.tool.samice</ToolType>
       <ToolName>SAM-ICE</ToolName>
@@ -35,7 +35,7 @@
       <ToolOptions>
         <InterfaceName>JTAG</InterfaceName>
         <InterfaceProperties>
-          <JtagDbgClock>0</JtagDbgClock>
+          <JtagDbgClock>4000000</JtagDbgClock>
           <JtagProgClock>1000000</JtagProgClock>
           <IspClock>150000</IspClock>
           <JtagInChain>false</JtagInChain>
@@ -73,7 +73,7 @@
       <ToolOptions>
         <InterfaceProperties>
           <SwdClock>0</SwdClock>
-          <JtagDbgClock>7500000</JtagDbgClock>
+          <JtagDbgClock>0</JtagDbgClock>
         </InterfaceProperties>
         <InterfaceName>JTAG</InterfaceName>
       </ToolOptions>
@@ -105,9 +105,9 @@
       <HWProgramCounterSampling>True</HWProgramCounterSampling>
     </PercepioTrace>
     <preserveEEPROM>true</preserveEEPROM>
-    <avrtoolserialnumber>J42700055544</avrtoolserialnumber>
+    <avrtoolserialnumber>28012829</avrtoolserialnumber>
     <avrdeviceexpectedsignature>0x285E0A60</avrdeviceexpectedsignature>
-    <avrtoolinterfaceclock>7500000</avrtoolinterfaceclock>
+    <avrtoolinterfaceclock>4000000</avrtoolinterfaceclock>
     <custom>
       <ToolOptions xmlns="">
         <InterfaceProperties>

--- a/g2core/plan_line.cpp
+++ b/g2core/plan_line.cpp
@@ -209,35 +209,37 @@ stat_t mp_aline(GCodeState_t* _gm)
 ////          ... so negative locations are the done with absolute values to mirror positive locations in steps from zero for the same value.
 ////    Second note: 1/17/23
 ////        - Kyle's testing turned up an issue with (too) small arcs not being flagged right. That issue is additionally resolved here.
-////        - The changes and issues are described in the PR.
-////        - As above, the solution is not efficient. It would be helpful if the following two for-loops could run in a single loop,
-////           .... but I have not been able to get it to work without messing up the location tracking.
 //// ========================================================================================= Setting Locations to Exact Step Locations Here
 ////                                                                                           By converting back and forth    
-    long int temp_toSteps;
+    
     for (uint8_t axis = 0; axis < AXES; axis++) {
-        int temp_sign = 1;
-        if ((flags[axis] = fp_NOT_ZERO(axis_length[axis]))) {  // yes, this supposed to be = not ==
-            if (target_rotated[axis] < 0 ) temp_sign = -1;
-            temp_toSteps = ((std::abs(target_rotated[axis]) * st_cfg.mot[axis].steps_per_unit) + .5);   // round interger of full steps 
-            target_rotated[axis] = (temp_toSteps * temp_sign) / st_cfg.mot[axis].steps_per_unit;        // convert back to float of true target location and asign sign
-        }
-    }
 
-    for (uint8_t axis = 0; axis < AXES; axis++) {
+        // make targets exact step locations
+        long int temp_toSteps;
+        int temp_sign = 1;
+        if (isnan(target_rotated[axis])) {
+                    // ignore NaN from arcs that are too small
+        } else {    // process good values    
+            if (target_rotated[axis] < 0 ) temp_sign = -1;                                              // see note on negative step rounding
+            temp_toSteps = ((std::abs(target_rotated[axis]) * st_cfg.mot[axis].steps_per_unit) + .5);   // round integer of full steps
+            target_rotated[axis] = (temp_toSteps * temp_sign) / st_cfg.mot[axis].steps_per_unit;        // convert back to float of true target location and asign sign
+        }        
+
+        // clean up final values
         axis_length[axis] = target_rotated[axis] - mp->position[axis];
-        if ((flags[axis] = fp_NOT_ZERO(axis_length[axis]))) {  // yes, this supposed to be = not ==
+        flags[axis] = fp_NOT_ZERO(axis_length[axis]);
+        if ( flags[axis] ) {                                                                              
             axis_square[axis] = square(axis_length[axis]);
             length_square += axis_square[axis];
         } else {
             axis_length[axis] = 0;  // make it truly zero if it was tiny
-            axis_square[axis] = 0;  // Fix bug that can kill feedholds by corrupting block_time in _calculate_times
+            axis_square[axis] = 0;  // Fix bug that can kill feed-holds by corrupting block_time in _calculate_times
         }
     }
+
     length = sqrt(length_square);
 
     // exit if the move has zero movement. At all.
-//    if (length < 0.00002) {  // this value is 2x EPSILON and prevents trap failures in _plan_aline()
     if (length < 0.0001) {      // this value is 0.1 microns. Prevents planner trap failures
         sr_request_status_report(SR_REQUEST_TIMED_FULL);  // Was SR_REQUEST_IMMEDIATE_FULL
         return (STAT_MINIMUM_LENGTH_MOVE);                // STAT_MINIMUM_LENGTH_MOVE needed to end cycle


### PR DESCRIPTION
This PR fixes issue # 1024 that Kyle reported in FabMo (not G2). It details at a distinct bug with arcs/circles that have very small diameters (such as might be used in a drilling plunge only slightly larger than the cutter). The new versions of G2 (after v101.57.37; versions that have the motion change that sets targets to the exact location of a step) work correctly with relatively small circles, but fail in the case where the circles are too small to cut. In this case, they should be skipped, but the newer version move towards 0,0 instead.

This appears to be the result of processing in plan_arc.cpp which sets a flag for the case of arc commands that should be skipped. The final planning in plan_line.cpp where the shift to exact step locations is done, was not detecting this condition. That detection has now been added.

This fix only requires a single line, but may represent an additional inefficiency in the processing of lines that is already burdened by having to go to integer and then back to floats to maintain step accuracy owing to G2 architecture. This should be something to reconsider in the future, particularly if we see G2 bogged down in the processing of files with a large number of small moves.

I have tested with the logo file and dev-test files on the handibot and things seem to run well. However, my step counter is not currently set-up and it would be great if someone with a counter set up could run a couple of those files we were using to test step accuracy. Thanks.
