### PR TITLE
fixes bug where a Stop Input during probing caused a hold but did not report stat: 6

### DIFF
--- a/g2core/board/sbv300/board_gpio.cpp
+++ b/g2core/board/sbv300/board_gpio.cpp
@@ -66,7 +66,6 @@ gpioDigitalInputPin<IRQPin<Motate::kInput7_PinNumber>>  din7  {DI7_ENABLED,  DI7
 gpioDigitalInputPin<IRQPin<Motate::kInput8_PinNumber>>  din8  {DI8_ENABLED,  DI8_POLARITY,  8, DI8_EXTERNAL_NUMBER, Motate::kPinInterruptOnChange|Motate::kPinInterruptPriorityHigh};
 gpioDigitalInputPin<IRQPin<Motate::kInput9_PinNumber>>  din9  {DI9_ENABLED,  DI9_POLARITY,  9, DI9_EXTERNAL_NUMBER, Motate::kPinInterruptOnChange|Motate::kPinInterruptPriorityHigh};
 gpioDigitalInputPin<IRQPin<Motate::kInput10_PinNumber>> din10 {DI10_ENABLED, DI10_POLARITY, 10, DI10_EXTERNAL_NUMBER, Motate::kPinInterruptOnChange|Motate::kPinInterruptPriorityHigh};
-////## enabled 10 & 11
 gpioDigitalInputPin<IRQPin<Motate::kInput11_PinNumber>> din11 {DI11_ENABLED, DI11_POLARITY, 11, DI11_EXTERNAL_NUMBER, Motate::kPinInterruptOnChange|Motate::kPinInterruptPriorityHigh};
 gpioDigitalInputPin<IRQPin<Motate::kInput12_PinNumber>> din12 {DI12_ENABLED, DI12_POLARITY, 12, DI12_EXTERNAL_NUMBER, Motate::kPinInterruptOnChange|Motate::kPinInterruptPriorityHigh};
 
@@ -86,7 +85,7 @@ gpioDigitalOutputPin<OutputType<OUTPUT13_PWM, Motate::kOutput13_PinNumber>> dout
 
 /**** Setup Arrays - these are extern and MUST match the board_gpio.h ****/
 
-gpioDigitalInput*  const d_in[] = {&din1, &din2, &din3, &din4, &din5, &din6, &din7, &din8, &din9, &din10};
+gpioDigitalInput*  const d_in[] = {&din1, &din2, &din3, &din4, &din5, &din6, &din7, &din8, &din9, &din10, &din11, &din12};
 gpioDigitalOutput* const d_out[] = {&dout1, &dout2, &dout3, &dout4, &dout5, &dout6, &dout7, &dout8, &dout9, &dout10, &dout11, &dout12, &dout13};
 // not yet used
 gpioAnalogInput*    a_in[] = {};

--- a/g2core/board/sbv300/board_gpio.h
+++ b/g2core/board/sbv300/board_gpio.h
@@ -81,7 +81,6 @@ extern gpioDigitalInputPin<IRQPin<Motate::kInput7_PinNumber>>  din7;
 extern gpioDigitalInputPin<IRQPin<Motate::kInput8_PinNumber>>  din8;
 extern gpioDigitalInputPin<IRQPin<Motate::kInput9_PinNumber>>  din9;
 extern gpioDigitalInputPin<IRQPin<Motate::kInput10_PinNumber>> din10;
-////## re-enabled 11 & 12
 extern gpioDigitalInputPin<IRQPin<Motate::kInput11_PinNumber>> din11;
 extern gpioDigitalInputPin<IRQPin<Motate::kInput12_PinNumber>> din12;
 

--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -401,7 +401,13 @@ cmCombinedState cm_get_combined_state(cmMachine_t *_cm)
 					case CYCLE_NONE:      { break; } // CYCLE_NONE cannot ever get here
 					case CYCLE_MACHINING: { return (_cm->hold_state == FEEDHOLD_OFF ? COMBINED_RUN : COMBINED_HOLD); }
 					case CYCLE_HOMING:    { return (COMBINED_HOMING); }
-					case CYCLE_PROBE:     { return (COMBINED_PROBE); }
+					case CYCLE_PROBE:   {
+                        if(_cm->hold_state == FEEDHOLD_HOLD){  // Allows picking up feedhold in a probe cycle
+                            return COMBINED_HOLD;
+                        } else {
+                            return (COMBINED_PROBE);
+                        }
+                    }
 					case CYCLE_JOG:       { return (COMBINED_JOG); }
 				}
 			}

--- a/g2core/stepper.cpp
+++ b/g2core/stepper.cpp
@@ -1128,6 +1128,9 @@ stat_t st_set_su(nvObj_t *nv)
     // You could scale any one of the other values, but TR makes the most sense
     st_cfg.mot[m].travel_rev = (360.0 * st_cfg.mot[m].microsteps) /
                                (st_cfg.mot[m].steps_per_unit * st_cfg.mot[m].step_angle);
+
+    kn_config_changed();
+
     return(STAT_OK);
 }
 


### PR DESCRIPTION
Arrrgh! Tried to change the name of this branch, but was too late process ... so it was just added to the older one. I think you should be able to pull in the change that was inspiringly suggested by @kyle-kingsbury to fix this problem.

Main issue was getting Stops (holds) during probing that parallel Stops during running. So they need to work when evoked by a Stop Button in the Dashboard and from a Stop Input. The Stop Input was generating a hold and report of hold conditions but it did not cause the immediate stat:6 on a hold that FabMo was expecting.

I've tested this in probing, homing and zeroing and regular running. It is necessary for the more general fixes made to FabMo at the same time. 